### PR TITLE
Adding deformation diagnostics

### DIFF
--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -939,7 +939,7 @@
 			<var name="t2m"/>
 			<var name="th2m"/>
 
-                        <!-- Begin isobaric diagnostics defined in diagnostics/Registry_isobaric.xml -->
+            <!-- Begin isobaric diagnostics defined in diagnostics/Registry_isobaric.xml -->
 			<var name="mslp"/>
 			<var name="relhum_200hPa"/>
 			<var name="relhum_250hPa"/>
@@ -994,41 +994,45 @@
 			<var name="z_isobaric"/>
 			<var name="z_iso_levels"/>
 			<var name="meanT_500_300"/>
-                        <!-- End isobaric diagnostics defined in diagnostics/Registry_isobaric.xml -->
+            <!-- End isobaric diagnostics defined in diagnostics/Registry_isobaric.xml -->
 
-                        <!-- Begin snow ratio diagnostics defined in diagnostics/Registry_snowratio.xml -->
-                        <var name="snow_ratio"/>
-                        <!-- End snow ratio diagnostics defined in diagnostics/Registry_snowratio.xml -->
+            <!-- Begin snow ratio diagnostics defined in diagnostics/Registry_snowratio.xml -->
+            <var name="snow_ratio"/>
+            <!-- End snow ratio diagnostics defined in diagnostics/Registry_snowratio.xml -->
+            
+            <!-- Begin deformation diagnostics defined in diagnostics/Registry_deformation.xml -->
+            <var name="deformation"/>
+            <!-- End deformation diagnostics defined in diagnostics/Registry_deformation.sxml -->
 
-                        <!-- Begin surface diagnostics defined in diagnostics/Registry_surface.xml -->
-                        <var name="dewpoint_2m"/>
-                        <var name="rain_bucket"/>
-                        <var name="conv_bucket"/>
-                        <var name="snow_bucket"/>
-                        <var name="zrain_bucket"/>
-                        <var name="snow_total"/>
-                        <var name="refl10cm_prate"/>
-                        <!-- End surface diagnostics defined in diagnostics/Registry_surface.xml -->
+            <!-- Begin surface diagnostics defined in diagnostics/Registry_surface.xml -->
+            <var name="dewpoint_2m"/>
+            <var name="rain_bucket"/>
+            <var name="conv_bucket"/>
+            <var name="snow_bucket"/>
+            <var name="zrain_bucket"/>
+            <var name="snow_total"/>
+            <var name="refl10cm_prate"/>
+            <!-- End surface diagnostics defined in diagnostics/Registry_surface.xml -->
 
-                        <!-- Begin convective diagnostics defined in diagnostics/Registry_convective.xml -->
-                        <var name="cape"/>
-                        <var name="cin"/>
-                        <var name="lcl"/>
-                        <var name="lfc"/>
-                        <var name="srh_0_1km"/>
-                        <var name="srh_0_3km"/>
-                        <var name="uzonal_surface"/>
-                        <var name="uzonal_1km"/>
-                        <var name="uzonal_6km"/>
-                        <var name="umeridional_surface"/>
-                        <var name="umeridional_1km"/>
-                        <var name="umeridional_6km"/>
-                        <var name="temperature_surface"/>
-                        <var name="dewpoint_surface"/>
+            <!-- Begin convective diagnostics defined in diagnostics/Registry_convective.xml -->
+            <var name="cape"/>
+            <var name="cin"/>
+            <var name="lcl"/>
+            <var name="lfc"/>
+            <var name="srh_0_1km"/>
+            <var name="srh_0_3km"/>
+            <var name="uzonal_surface"/>
+            <var name="uzonal_1km"/>
+            <var name="uzonal_6km"/>
+            <var name="umeridional_surface"/>
+            <var name="umeridional_1km"/>
+            <var name="umeridional_6km"/>
+            <var name="temperature_surface"/>
+            <var name="dewpoint_surface"/>
 			<var name="updraft_helicity_max"/>
 			<var name="w_velocity_max"/>
 			<var name="wind_speed_level1_max"/>
-                        <!-- End convective diagnostics defined in diagnostics/Registry_convective.xml -->
+            <!-- End convective diagnostics defined in diagnostics/Registry_convective.xml -->
 
 			<var name="t_oml"/>
 			<var name="t_oml_initial"/>

--- a/src/core_atmosphere/diagnostics/Makefile
+++ b/src/core_atmosphere/diagnostics/Makefile
@@ -8,8 +8,9 @@ DIAGNOSTIC_MODULES = \
 	isobaric_diagnostics.o \
 	convective_diagnostics.o \
 	pv_diagnostics.o \
-        snowratio_diagnostics.o \
-        surface_diagnostics.o \
+    snowratio_diagnostics.o \
+    surface_diagnostics.o \
+    deformation_diagnostics.o
 	soundings.o \
 
 isobaric_diagnostics.o: mpas_atm_diagnostics_utils.o
@@ -21,6 +22,8 @@ pv_diagnostics.o: mpas_atm_diagnostics_utils.o
 snowratio_diagnostics.o: mpas_atm_diagnostics_utils.o
 
 surface_diagnostics.o: mpas_atm_diagnostics_utils.o
+
+deformation_diagnostics.o: mpas_atm_diagnostics_utils.o
 
 soundings.o:
 

--- a/src/core_atmosphere/diagnostics/Makefile
+++ b/src/core_atmosphere/diagnostics/Makefile
@@ -8,9 +8,9 @@ DIAGNOSTIC_MODULES = \
 	isobaric_diagnostics.o \
 	convective_diagnostics.o \
 	pv_diagnostics.o \
-    snowratio_diagnostics.o \
-    surface_diagnostics.o \
-    deformation_diagnostics.o
+	snowratio_diagnostics.o \
+	surface_diagnostics.o \
+	deformation_diagnostics.o \
 	soundings.o \
 
 isobaric_diagnostics.o: mpas_atm_diagnostics_utils.o

--- a/src/core_atmosphere/diagnostics/Registry_deformation.xml
+++ b/src/core_atmosphere/diagnostics/Registry_deformation.xml
@@ -1,7 +1,7 @@
 <!-- *************************************************************** -->
 <!-- Wind deformation diagnostics for GTG calculations               -->
 <!--                                                                 -->
-<!-- Created by John Wong, November / 2017
+<!-- Created by John Wong, November / 2017                           -->
 <!-- Copyright (c) 2017 The Weather Company. All rights reserved.    -->
 <!-- *************************************************************** -->
 

--- a/src/core_atmosphere/diagnostics/Registry_deformation.xml
+++ b/src/core_atmosphere/diagnostics/Registry_deformation.xml
@@ -1,0 +1,14 @@
+<!-- *************************************************************** -->
+<!-- Wind deformation diagnostics for GTG calculations               -->
+<!--                                                                 -->
+<!-- Created by John Wong, November / 2017
+<!-- Copyright (c) 2017 The Weather Company. All rights reserved.    -->
+<!-- *************************************************************** -->
+
+<var_struct name="diag" time_levs="1">
+    
+    <var name="deformation" type="real" dimensions="nVertLevels nCells Time" units="s^{-1}"
+         description="Horizontal deformation"/>
+    
+</var_struct>
+

--- a/src/core_atmosphere/diagnostics/Registry_diagnostics.xml
+++ b/src/core_atmosphere/diagnostics/Registry_diagnostics.xml
@@ -22,6 +22,9 @@
 <!-- snow ratio diagnostics -->
 #include "Registry_snowratio.xml"
 
+<!-- deformation diagnostics -->
+#include "Registry_deformation.xml"
+
 <!-- ******************************* -->
 <!-- End includes from diagnostics -->
 <!-- ******************************* -->

--- a/src/core_atmosphere/diagnostics/deformation_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/deformation_diagnostics.F
@@ -74,6 +74,7 @@ module deformation_diagnostics
     subroutine deformation_diagnostics_compute()
 
         use mpas_pool_routines, only : mpas_pool_get_dimension, mpas_pool_get_array
+        use mpas_atm_diagnostics_utils, only : MPAS_field_will_be_written
 
         implicit none
 
@@ -92,48 +93,48 @@ module deformation_diagnostics
 
         integer :: iEdge, iCell, k, e
 
+        if ( MPAS_field_will_be_written('deformation') ) then
+            ! Mesh information
+            call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+            call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+            call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
+            call mpas_pool_get_array(mesh, 'edgesOnCell', edgesOnCell)
 
-        ! Mesh information
-        call mpas_pool_get_dimension(mesh, 'nCells', nCells)
-        call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
-        call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
-        call mpas_pool_get_array(mesh, 'edgesOnCell', edgesOnCell)
+            ! States and diagnostics, integration coefficients
+            call mpas_pool_get_array(state, 'u', u, 2)
+            call mpas_pool_get_array(diag, 'v', v)
+            call mpas_pool_get_array(mesh, 'defc_a', defc_a)
+            call mpas_pool_get_array(mesh, 'defc_b', defc_b)
 
-        ! States and diagnostics, integration coefficients
-        call mpas_pool_get_array(state, 'u', u, 2)
-        call mpas_pool_get_array(diag, 'v', v)
-        call mpas_pool_get_array(mesh, 'defc_a', defc_a)
-        call mpas_pool_get_array(mesh, 'defc_b', defc_b)
+            ! Target array
+            call mpas_pool_get_array(diag, 'deformation', deformation)
 
-        ! Target array
-        call mpas_pool_get_array(diag, 'deformation', deformation)
+            ! Allocate arrays for holding diagonal and off-diagonal deformation terms
+            allocate(d_diag(nVertLevels))
+            allocate(d_off_diag(nVertLevels))
 
-        ! Allocate arrays for holding diagonal and off-diagonal deformation terms
-        allocate(d_diag(nVertLevels))
-        allocate(d_off_diag(nVertLevels))
+            do iCell=1,nCells
+                d_diag(:) = 0.0
+                d_off_diag(:) = 0.0
 
-        do iCell=1,nCells
-            d_diag(:) = 0.0
-            d_off_diag(:) = 0.0
+                ! Integrate over edges around the cell
+                do iEdge=1,nEdgesOnCell(iCell)
+                    e = edgesOnCell(iEdge,iCell)
+                    d_diag(:)     = d_diag(:)     + defc_a(iEdge,iCell)*u(:,e) - &
+                                                    defc_b(iEdge,iCell)*v(:,e)
+                    d_off_diag(:) = d_off_diag(:) + defc_b(iEdge,iCell)*u(:,e) + &
+                                                    defc_a(iEdge,iCell)*v(:,e)
+                end do
 
-            ! Integrate over edges around the cell
-            do iEdge=1,nEdgesOnCell(iCell)
-                e = edgesOnCell(iEdge,iCell)
-                d_diag(:)     = d_diag(:)     + defc_a(iEdge,iCell)*u(:,e) - &
-                                                defc_b(iEdge,iCell)*v(:,e)
-                d_off_diag(:) = d_off_diag(:) + defc_b(iEdge,iCell)*u(:,e) + &
-                                                defc_a(iEdge,iCell)*v(:,e)
+                ! Combine the diagonal and off-diagonal terms
+                deformation(:,iCell) = sqrt(d_diag(:)**2 + d_off_diag(:)**2)
             end do
 
-            ! Combine the diagonal and off-diagonal terms
-            deformation(:,iCell) = sqrt(d_diag(:)**2 + d_off_diag(:)**2)
-        end do
-
-        deallocate(d_diag)
-        deallocate(d_off_diag)
+            deallocate(d_diag)
+            deallocate(d_off_diag)
+        end if
 
     end subroutine deformation_diagnostics_compute
-
 
 
     subroutine deformation_diagnostics_reset()

--- a/src/core_atmosphere/diagnostics/deformation_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/deformation_diagnostics.F
@@ -1,0 +1,152 @@
+!  deformation_diagnostics.F
+!
+!  Created by John Wong, October / 2017
+!  Copyright (c) 2017 The Weather Company. All rights reserved.
+!
+!  This module computes wind deformation based on method used in the
+!  implementation for 2D Smagorinsky eddy viscosity in atm_compute_dyn_tend_work.
+!
+!----------------------------------------------------------------------->
+
+module deformation_diagnostics
+
+    use mpas_derived_types, only : MPAS_pool_type
+    use mpas_kind_types, only : RKIND
+
+    type (MPAS_pool_type), pointer :: mesh
+    type (MPAS_pool_type), pointer :: state
+    type (MPAS_pool_type), pointer :: diag
+
+    public :: deformation_diagnostics_setup, &
+              deformation_diagnostics_update, &
+              deformation_diagnostics_compute, &
+              deformation_diagnostics_reset, &
+              deformation_diagnostics_cleanup
+
+    private
+
+    contains
+
+
+    !-----------------------------------------------------------------------
+    !  routine deformation_diagnostics_setup
+    !
+    !> \brief   Initialize the deformation_diagnostics module
+    !> \author  John Wong
+    !> \date    20 Nov 2017
+    !> \details
+    !>  Initialize the diagnostic module.
+    !
+    !-----------------------------------------------------------------------
+    subroutine deformation_diagnostics_setup(all_pools)
+
+        use mpas_derived_types, only : MPAS_pool_type, MPAS_clock_type
+        use mpas_pool_routines, only : mpas_pool_get_subpool
+
+        implicit none
+
+        type (MPAS_pool_type), pointer :: all_pools
+
+        call mpas_pool_get_subpool(all_pools, 'mesh', mesh)
+        call mpas_pool_get_subpool(all_pools, 'state', state)
+        call mpas_pool_get_subpool(all_pools, 'diag', diag)
+
+    end subroutine deformation_diagnostics_setup
+
+
+    subroutine deformation_diagnostics_update()
+        implicit none
+        ! Nothing to update (every timestep) for deformation
+    end subroutine deformation_diagnostics_update
+
+
+    !-----------------------------------------------------------------------
+    !  routine deformation_diagnostics_compute
+    !
+    !> \brief  Compute deformation for model output
+    !> \author John Wong
+    !> \date   20 Nov 2017
+    !> \details
+    !>  Compute deformation diagnostic before model output is written. Implementation
+    !>  is based on that done for Smagorinsky horizontal eddy viscosity.
+    !
+    !-----------------------------------------------------------------------
+    subroutine deformation_diagnostics_compute()
+
+        use mpas_pool_routines, only : mpas_pool_get_dimension, mpas_pool_get_array
+
+        implicit none
+
+        integer, pointer :: nCells, nVertLevels, nEdges
+        integer, dimension(:), pointer :: nEdgesOnCell
+        integer, dimension(:,:), pointer :: edgesOnCell
+
+        real (kind=RKIND), dimension(:,:), pointer :: u
+        real (kind=RKIND), dimension(:,:), pointer :: v
+        real (kind=RKIND), dimension(:,:), pointer :: defc_a
+        real (kind=RKIND), dimension(:,:), pointer :: defc_b
+
+        real (kind=RKIND), dimension(:), allocatable :: d_diag, d_off_diag
+
+        real (kind=RKIND), dimension(:,:), pointer :: deformation
+
+        integer :: iEdge, iCell, k, e
+
+
+        ! Mesh information
+        call mpas_pool_get_dimension(mesh, 'nCells', nCells)
+        call mpas_pool_get_dimension(mesh, 'nVertLevels', nVertLevels)
+        call mpas_pool_get_array(mesh, 'nEdgesOnCell', nEdgesOnCell)
+        call mpas_pool_get_array(mesh, 'edgesOnCell', edgesOnCell)
+
+        ! States and diagnostics, integration coefficients
+        call mpas_pool_get_array(state, 'u', u, 2)
+        call mpas_pool_get_array(diag, 'v', v)
+        call mpas_pool_get_array(mesh, 'defc_a', defc_a)
+        call mpas_pool_get_array(mesh, 'defc_b', defc_b)
+
+        ! Target array
+        call mpas_pool_get_array(diag, 'deformation', deformation)
+
+        ! Allocate arrays for holding diagonal and off-diagonal deformation terms
+        allocate(d_diag(nVertLevels))
+        allocate(d_off_diag(nVertLevels))
+
+        do iCell=1,nCells
+            d_diag(:) = 0.0
+            d_off_diag(:) = 0.0
+
+            ! Integrate over edges around the cell
+            do iEdge=1,nEdgesOnCell(iCell)
+                e = edgesOnCell(iEdge,iCell)
+                d_diag(:)     = d_diag(:)     + defc_a(iEdge,iCell)*u(:,e) - &
+                                                defc_b(iEdge,iCell)*v(:,e)
+                d_off_diag(:) = d_off_diag(:) + defc_b(iEdge,iCell)*u(:,e) + &
+                                                defc_a(iEdge,iCell)*v(:,e)
+            end do
+
+            ! Combine the diagonal and off-diagonal terms
+            deformation(:,iCell) = sqrt(d_diag(:)**2 + d_off_diag(:)**2)
+        end do
+
+        deallocate(d_diag)
+        deallocate(d_off_diag)
+
+    end subroutine deformation_diagnostics_compute
+
+
+
+    subroutine deformation_diagnostics_reset()
+        implicit none
+        ! Nothing to reset for deformation
+    end subroutine deformation_diagnostics_reset
+
+
+    subroutine deformation_diagnostics_cleanup()
+        implicit none
+        ! Nothing to cleanup for deformation
+    end subroutine deformation_diagnostics_cleanup
+
+
+end module deformation_diagnostic
+

--- a/src/core_atmosphere/diagnostics/deformation_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/deformation_diagnostics.F
@@ -148,5 +148,5 @@ module deformation_diagnostics
     end subroutine deformation_diagnostics_cleanup
 
 
-end module deformation_diagnostic
+end module deformation_diagnostics
 

--- a/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
+++ b/src/core_atmosphere/diagnostics/mpas_atm_diagnostics_manager.F
@@ -39,6 +39,7 @@ module mpas_atm_diagnostics_manager
         use convective_diagnostics, only : convective_diagnostics_setup
         use snowratio_diagnostics, only : snowratio_diagnostics_setup
         use surface_diagnostics, only : surface_diagnostics_setup
+        use deformation_diagnostics, only : deformation_diagnostics_setup
         use pv_diagnostics, only : pv_diagnostics_setup
         use soundings, only : soundings_setup
 
@@ -61,6 +62,7 @@ module mpas_atm_diagnostics_manager
         call convective_diagnostics_setup(structs, clock)
         call snowratio_diagnostics_setup(configs, structs)
         call surface_diagnostics_setup(configs, structs, clock)
+        call deformation_diagnostics_setup(structs)
         call pv_diagnostics_setup(structs, clock)
         call soundings_setup(configs, structs, clock, dminfo)
 
@@ -103,12 +105,12 @@ module mpas_atm_diagnostics_manager
     !-----------------------------------------------------------------------
     subroutine mpas_atm_diag_compute()
 
-        use mpas_derived_types, only : mpas_pool_type
         use diagnostic_template, only : diagnostic_template_compute
         use isobaric_diagnostics, only : isobaric_diagnostics_compute
         use convective_diagnostics, only : convective_diagnostics_compute
         use snowratio_diagnostics, only : snowratio_diagnostics_compute
         use surface_diagnostics, only : surface_diagnostics_compute
+        use deformation_diagnostics, only : deformation_diagnostics_compute
         use pv_diagnostics, only : pv_diagnostics_compute
         use soundings, only : soundings_compute
 
@@ -119,6 +121,7 @@ module mpas_atm_diagnostics_manager
         call convective_diagnostics_compute()
         call snowratio_diagnostics_compute()
         call surface_diagnostics_compute()
+        call deformation_diagnostics_compute()
         call pv_diagnostics_compute()
         call soundings_compute()
 


### PR DESCRIPTION
Computing deformation diagnostic based on defc_a and defc_b as well as normal and tangential velocities around individual cells. Based on formulation used in the implementation for Smagorinsky horizontal mixing scheme.