### PR TITLE
adds config_stop to streams

### DIFF
--- a/README.mac_compile
+++ b/README.mac_compile
@@ -1,0 +1,17 @@
+1. Manually install PIO2:
+ cd $MPAS/software
+ git clone git@github.com:NCAR/ParallelIO.git
+  cd ParallelIO
+  export PIOSRC=`pwd`
+  cd ..
+  mkdir pio_build
+  cd pio_build
+  export CC=mpicc
+  export FC=mpif90
+  cmake -DNetCDF_C_PATH=$NETCDF -DNetCDF_Fortran_PATH=$NETCDF -DPnetCDF_PATH=$PNETCDF \
+        -DCMAKE_INSTALL_PREFIX=${MPAS}/libraries -DPIO_ENABLE_TIMING=OFF $PIOSRC
+  make
+  make install
+
+2. Install parallel netcdf
+I can't remember how, because I already had it setup in $MPAS/libraries

--- a/mpas_mac_compile.sh
+++ b/mpas_mac_compile.sh
@@ -1,0 +1,83 @@
+#!/bin/sh -f
+
+
+export MPAS_ROOT=`pwd`
+export WRFIO_NCD_LARGE_FILE_SUPPORT=1
+
+export serial_FC
+export NETCDF=/usr/local/
+export HDF5_DIR=/usr/local
+export PNETCDF=$MPAS_ROOT/libraries
+export PNETCDF_PATH=$MPAS_ROOT/libraries
+export PIO=$MPAS_ROOT/libraries
+export serial_FC=gfortran-5
+export FC=gfortran-5
+export CC=gcc-5
+export CXX=g++-5
+export OMPI_CC=$CC
+export OMPI_CXX=$CXX
+export OMPI_FC=$FC
+export MPICC=mpicc
+export MPIF77=mpifort
+export MPIF90=mpifort
+export MPIFC=mpifort
+export target=gfortran
+export USE_PIO2_MPAS=true
+cd $MPAS_ROOT/software
+
+
+echo "******************"
+echo "(2) Building MPAS"
+echo "******************"
+
+cd $MPAS_ROOT
+
+#export MPAS_EXTERNAL_LIBS="-L/usr/lib64 -ldl -lz -L${HDF5_DIR}/lib -lhdf5_hl -lhdf5"
+#export MPAS_EXTERNAL_INCLUDES="-I${HDF5_DIR}/include -I/usr/include" 
+
+# 1st:  init_atmosphere
+make clean CORE=init_atmosphere
+make ${target} CORE=init_atmosphere PRECISION=single USE_PIO2=${USE_PIO2_MPAS}
+
+# 2nd:  atmosphere
+#make clean CORE=atmosphere
+#make ${target} CORE=atmosphere PRECISION=single USE_PIO2=${USE_PIO2_MPAS}
+
+mkdir logs
+mkdir data
+mkdir run
+mkdir geocache
+
+
+echo "**************************"
+echo "(3) Building metis-5.1.0"
+echo "**************************"
+
+cd $MPAS_ROOT
+
+rm -rf metis-5.1.0
+tar -xvzf metis-5.1.0.tar.gz
+
+cd metis-5.1.0
+make config
+make
+
+echo "*****************************"
+echo "(4) Building double_to_float"
+echo "*****************************"
+
+cd $MPAS_ROOT/dbl2flt/
+${serial_FC} -o double_to_float_grid double_to_float_grid.f90 -I${NETCDF}/include -L${NETCDF}/lib -lnetcdff -lnetcdf
+
+
+echo "*****************************"
+echo "(5) Building grid_rotate"
+echo "*****************************"
+
+cd $MPAS_ROOT/grid_rotate/
+make clean
+make FFLAGS=-ffree-line-length-none
+
+echo "DONE BUILDING EVERYTHING FOR MPAS ... "
+
+exit

--- a/src/core_atmosphere/Registry.xml
+++ b/src/core_atmosphere/Registry.xml
@@ -489,6 +489,7 @@
                         filename_template="restart.$Y-$M-$D_$h.$m.$s.nc" 
                         input_interval="initial_only" 
                         output_interval="1_00:00:00" 
+                        output_stop="none"
                         immutable="true">
 
 			<var name="latCell"/>
@@ -805,6 +806,7 @@
                         type="output" 
                         filename_template="history.$Y-$M-$D_$h.$m.$s.nc" 
                         output_interval="6:00:00"
+                        output_stop="none"
                         runtime_format="separate_file">
 
 			<var name="latCell"/>

--- a/src/core_atmosphere/physics/mpas_atmphys_manager.F
+++ b/src/core_atmosphere/physics/mpas_atmphys_manager.F
@@ -554,6 +554,9 @@
  if (config_sst_update) then
     call MPAS_stream_mgr_get_property(stream_manager, 'surface', MPAS_STREAM_PROPERTY_RECORD_INTV, stream_interval, &
                                       direction=MPAS_STREAM_INPUT, ierr=ierr)
+    if (trim(stream_interval) .eq. "none") &
+        call physics_error_fatal('subroutine physics_init: No time interval found for sstupdate, maybe '// &
+                                  'config_sst_update should be set to false?')
     call mpas_set_timeInterval(alarmTimeStep,timeString=stream_interval,ierr=ierr)
     alarmStartTime = startTime
     call mpas_add_clock_alarm(clock,sfcbdyAlarmID,alarmStartTime,alarmTimeStep,ierr=ierr)

--- a/src/core_init_atmosphere/mpas_init_atm_static.F
+++ b/src/core_init_atmosphere/mpas_init_atm_static.F
@@ -765,6 +765,9 @@ if (rarray(i,j,1) == 0) cycle
           shdmax(iCell) = maxval(greenfrac(:,iCell))
       
        end do
+       ! DEALLOCATE arrays
+       deallocate(rarray)
+       deallocate(vegfra)
 
     ! Now the VIIRS data ...
 
@@ -826,14 +829,14 @@ if (rarray(i,j,1) == 0) cycle
           shdmax(iCell) = maxval(greenfrac(:,iCell))
 
        end do
+       ! DEALLOCATE arrays
+       deallocate(rarray)
+       deallocate(vegfra)
 
     case default
 
  end select greenfrac_select
 
- ! DEALLOCATE arrays
- deallocate(rarray)
- deallocate(vegfra)
  write(0,*) '--- end interpolate GREENFRAC'
 
 

--- a/src/framework/mpas_stream_manager.F
+++ b/src/framework/mpas_stream_manager.F
@@ -5810,7 +5810,7 @@ subroutine stream_mgr_add_immutable_stream_fields_c(manager_c, streamID_c, refSt
 end subroutine stream_mgr_add_immutable_stream_fields_c !}}}
 
 
-subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_c, alarmInterval_c, ierr_c) bind(c) !{{{
+subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_c, alarmInterval_c, alarmStopInterval_c, ierr_c) bind(c) !{{{
 
     use mpas_c_interfacing, only : mpas_c_to_f_string
     use iso_c_binding, only : c_char, c_int, c_ptr, c_f_pointer
@@ -5818,7 +5818,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
                                         MPAS_STREAM_MGR_NOERR, MPAS_STREAM_INPUT, MPAS_STREAM_OUTPUT, MPAS_START_TIME
     use mpas_stream_manager, only : MPAS_stream_mgr_get_clock, MPAS_stream_mgr_add_alarm
     use mpas_kind_types, only : StrKIND
-    use mpas_timekeeping, only : mpas_add_clock_alarm, mpas_set_time, mpas_set_timeInterval, mpas_get_clock_time
+    use mpas_timekeeping, only : mpas_add_clock_alarm, mpas_set_time, mpas_set_timeInterval, mpas_get_clock_time, operator (-)
 
     implicit none
 
@@ -5827,16 +5827,16 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
     character(kind=c_char) :: direction_c(*)
     character(kind=c_char) :: alarmTime_c(*)
     character(kind=c_char) :: alarmInterval_c(*)
+    character(kind=c_char) :: alarmStopInterval_c(*)
     integer(kind=c_int) :: ierr_c
 
     type (MPAS_streamManager_type), pointer :: manager
     type (MPAS_Clock_type), pointer :: clock
-    character(len=StrKIND) :: streamID, direction, alarmID, alarmTime, alarmInterval
+    character(len=StrKIND) :: streamID, direction, alarmID, alarmTime, alarmInterval, alarmStopInterval
     type (MPAS_Time_type) :: alarmTime_local
-    type (MPAS_TimeInterval_type) :: alarmInterval_local
+    type (MPAS_TimeInterval_type) :: alarmInterval_local, alarmStopInterval_local
     integer :: idirection
     integer :: ierr
-
 
     ierr = 0
 
@@ -5845,6 +5845,7 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
     call mpas_c_to_f_string(direction_c, direction)
     call mpas_c_to_f_string(alarmTime_c, alarmTime)
     call mpas_c_to_f_string(alarmInterval_c, alarmInterval)
+    call mpas_c_to_f_string(alarmStopInterval_c, alarmStopInterval)
     write(alarmID, '(a)') trim(streamID)//'_'//trim(direction)
 
     ! Nothing to do for this stream
@@ -5870,7 +5871,14 @@ subroutine stream_mgr_add_alarm_c(manager_c, streamID_c, direction_c, alarmTime_
         call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, ierr=ierr)
     else
         call mpas_set_timeInterval(alarmInterval_local, timeString=alarmInterval)
-        call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, alarmTimeInterval=alarmInterval_local, ierr=ierr)
+        if (trim(alarmStopInterval) == 'none') then
+             call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, &
+                 alarmTimeInterval=alarmInterval_local, ierr=ierr)
+        else
+            call mpas_set_timeInterval(alarmStopInterval_local, timeString=alarmStopInterval)
+            call mpas_add_clock_alarm(clock, alarmID, alarmTime_local, alarmTimeInterval=alarmInterval_local, &
+                                  alarmStopInterval=alarmStopInterval_local,ierr=ierr)
+        end if
     end if
 
     call MPAS_stream_mgr_add_alarm(manager, streamID, alarmID, idirection, ierr=ierr)

--- a/src/framework/mpas_timekeeping.F
+++ b/src/framework/mpas_timekeeping.F
@@ -471,8 +471,7 @@ module mpas_timekeeping
    end function mpas_get_clock_time
 
 
-   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, ierr)
-! TODO: possibly add a stop time for recurring alarms
+   subroutine mpas_add_clock_alarm(clock, alarmID, alarmTime, alarmTimeInterval, alarmStopInterval, ierr)
 
       implicit none
 
@@ -480,6 +479,7 @@ module mpas_timekeeping
       character (len=*), intent(in) :: alarmID
       type (MPAS_Time_type), intent(in) :: alarmTime
       type (MPAS_TimeInterval_type), intent(in), optional :: alarmTimeInterval
+      type (MPAS_TimeInterval_type), intent(in), optional :: alarmStopInterval
       integer, intent(out), optional :: ierr
 
       type (MPAS_Alarm_type), pointer :: alarmPtr
@@ -540,6 +540,12 @@ module mpas_timekeeping
             alarmPtr % isRecurring = .false.
             alarmPtr % prevRingTime = alarmTime
          end if
+         if (present(alarmStopInterval)) then
+             alarmPtr % isOutputStopSet = .true.
+             alarmPtr % ringStopInterval = alarmStopInterval
+         else
+             alarmPtr % isOutputStopSet = .false.
+         endif
          if (present(ierr)) then
             if (ierr == ESMF_SUCCESS) ierr = 0
          end if
@@ -729,6 +735,8 @@ module mpas_timekeeping
                
                write(stderrUnit,*) 'isSet', alarmPtr % isSet
 
+               write(stderrUnit,*) 'isOutputStopSet', alarmPtr % isOutputStopSet
+
                call mpas_get_time(alarmPtr % ringTime, dateTimeString=printString, ierr=ierr)
                write(stderrUnit,*) 'ringTime', printString
 
@@ -737,6 +745,9 @@ module mpas_timekeeping
 
                call mpas_get_timeInterval(alarmPtr % ringTimeInterval, timeString=printString, ierr=ierr)
                write(stderrUnit,*) 'ringTimeInterval', printString
+
+               call mpas_get_timeInterval(alarmPtr % ringStopInterval, timeString=printString, ierr=ierr)
+               write(stderrUnit,*) 'ringStopInterval', printString
                
                exit
             end if
@@ -822,10 +833,11 @@ module mpas_timekeeping
       
       type (MPAS_Time_type) :: alarmNow
       type (MPAS_Time_type) :: alarmThreshold
+      type (MPAS_Time_type) :: stopThreshold
 
       alarmNow = mpas_get_clock_time(clock, MPAS_NOW, ierr)
-      alarmThreshold = alarmPtr % ringTime 
-      
+      alarmThreshold = alarmPtr % ringTime
+     
       mpas_in_ringing_envelope = .false.      
                
       if(clock % direction == MPAS_FORWARD) then
@@ -838,10 +850,22 @@ module mpas_timekeeping
             alarmThreshold = alarmPtr % prevRingTime + alarmPtr % ringTimeInterval
          end if
 
-         if (alarmThreshold <= alarmNow) then
-            mpas_in_ringing_envelope = .true.
-         end if
-      else
+        if (alarmPtr % isOutputStopSet) then
+             ! First, if we have an outputStop time, make sure that Now is both prior to stop and alarmThreshold
+             !   (from interval) is within range.
+             stopThreshold = mpas_get_clock_time(clock, MPAS_START_TIME, ierr) + alarmPtr % ringStopInterval
+             if ( (alarmNow <= stopThreshold) .and. (alarmThreshold <= alarmNow) ) then
+                 mpas_in_ringing_envelope = .true.
+             endif
+         else
+             ! Next, since there is not otuput stop, simply make sure that Now is within alarmThreshold
+             !   (from interval) is within range.
+             if (alarmThreshold <= alarmNow) then
+                 mpas_in_ringing_envelope = .true.
+             endif
+         endif
+
+     else
 
          if (present(interval)) then
             alarmNow = alarmNow - interval; 
@@ -851,10 +875,21 @@ module mpas_timekeeping
             alarmThreshold = alarmPtr % prevRingTime - alarmPtr % ringTimeInterval
          end if
             
-         if (alarmThreshold >= alarmNow) then
-            mpas_in_ringing_envelope = .true.
-         end if
-      end if
+         if (alarmPtr % isOutputStopSet) then
+             ! First, if we have an outputStop time, make sure that Now is both prior to stop and alarmThreshold
+             !   (from interval) is within range.
+             stopThreshold = mpas_get_clock_time(clock, MPAS_START_TIME, ierr) - alarmPtr % ringStopInterval
+             if ( (alarmNow >= stopThreshold) .and. (alarmThreshold >= alarmNow) ) then
+                 mpas_in_ringing_envelope = .true.
+             endif
+         else
+             ! Next, since there is not otuput stop, simply make sure that Now is within alarmThreshold
+             !   (from interval) is within range.
+             if (alarmThreshold <= alarmNow) then
+                 mpas_in_ringing_envelope = .true.
+             endif
+         endif
+     end if
 
    end function mpas_in_ringing_envelope
 

--- a/src/framework/mpas_timekeeping_types.inc
+++ b/src/framework/mpas_timekeeping_types.inc
@@ -23,9 +23,11 @@
       character (len=ShortStrKIND) :: alarmID
       logical :: isRecurring
       logical :: isSet
+      logical :: isOutputStopSet
       type (MPAS_Time_type) :: ringTime
       type (MPAS_Time_type) :: prevRingTime
       type (MPAS_TimeInterval_type) :: ringTimeInterval
+      type (MPAS_TimeInterval_type) :: ringStopInterval
       type (MPAS_Alarm_type), pointer :: next
    end type
    

--- a/src/tools/input_gen/streams_gen.c
+++ b/src/tools/input_gen/streams_gen.c
@@ -319,7 +319,7 @@ int generate_streams(ezxml_t registry, FILE* fd, char *stream_file_prefix, int o
 
 void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/
 	const char *name, *type, *immutable, *filename_template, *filename_interval, *packages, *record_interval;
-	const char *reference_time, *clobber_mode, *precision, *input_interval, *output_interval, *io_type;
+	const char *reference_time, *clobber_mode, *precision, *input_interval, *output_interval, *output_stop, *io_type;
 
 	char spacing[1024];
 
@@ -331,6 +331,7 @@ void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/
 	clobber_mode = ezxml_attr(stream_xml, "clobber_mode");
 	input_interval = ezxml_attr(stream_xml, "input_interval");
 	output_interval = ezxml_attr(stream_xml, "output_interval");
+        output_stop = ezxml_attr(stream_xml, "output_stop");
 	record_interval = ezxml_attr(stream_xml, "record_interval");
 	precision = ezxml_attr(stream_xml, "precision");
 	io_type = ezxml_attr(stream_xml, "io_type");
@@ -375,6 +376,9 @@ void write_stream_header(ezxml_t stream_xml, FILE *fd){/*{{{*/
 	if ( output_interval != NULL ) {
 		fprintf(fd, "\n%soutput_interval=\"%s\"", spacing, output_interval);
 	}
+        if ( output_stop != NULL ) {
+            fprintf(fd, "\n%soutput_stop=\"%s\"", spacing, output_stop);
+        }
 
 	if (immutable != NULL && strcmp(immutable, "true") == 0){
 		fprintf(fd, " />\n\n");

--- a/src/tools/registry/Registry.xsd
+++ b/src/tools/registry/Registry.xsd
@@ -103,6 +103,9 @@
 						<!-- The output_interval is required if type contains output. It defines the standard interval for how often the stream manager should handle this stream.
 							 Valid options are "YYYY-MM-DD_hh:mm:ss", "initial_only", or "none" -->
 						<xs:attribute name="output_interval"  type="xs:string" use="optional"/>
+                                                <!-- The output_stop specifies when to stop writing output.  Valid options are "YYYY-MM-DD_hh:mm:ss" or "none".
+                                                     "none" indicates that data should be written through to the end of the run, and is the default. -->
+                                                <xs:attribute name="output_stop"  type="xs:string" use="optional"/>
 						<!-- The input_interval is required if type contains output. It defines the standard interval for how often the stream manager should handle this stream.
 							 Valid options are "YYYY-MM-DD_hh:mm:ss", "initial_only", or "none" -->
 						<xs:attribute name="input_interval"  type="xs:string" use="optional"/>


### PR DESCRIPTION
This pull request is to incorporate the ability to specify a stop for the output of a stream (e.g., history or diagnostics). To utilize it, add something similare to the following to a stanza in the streams.atmosphere file

output_stop="03_00:00:00"

To stop output after day 3.

I have not incorporated the configuration into the streams.atmosphere that drives our operational runs yet.  

