### PR TITLE
Fixes frontogenesis inconsistency

### DIFF
--- a/src/core_atmosphere/diagnostics/turbulence_diagnostics.F
+++ b/src/core_atmosphere/diagnostics/turbulence_diagnostics.F
@@ -140,8 +140,8 @@ module turbulence_diagnostics
         end if
         if (stream_fronto) then
             call mpas_pool_get_array(diag, 'theta', theta)
-            th_old(1:nTurbulenceLevels,:)  = th_save(1:nTurbulenceLevels,:)
-            th_save(1:nTurbulenceLevels,:) = theta(1:nTurbulenceLevels,:)
+            th_old(1:nTurbulenceLevels+1,:)  = th_save(1:nTurbulenceLevels+1,:)
+            th_save(1:nTurbulenceLevels+1,:) = theta(1:nTurbulenceLevels+1,:)
         end if
     end subroutine turbulence_diagnostics_update
 


### PR DESCRIPTION
Inconsistency occurs at the top of the turbulence levels (first level not used by postproc). This level is impacted by the uninitialized level above.